### PR TITLE
Remake internal signature form using Material UI.

### DIFF
--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -1,8 +1,18 @@
 import type { NextPage } from "next";
-import { Button, Container, Divider, FormControl, Grid, Stack, TextField, ThemeProvider, Typography} from "@mui/material";
+import {
+  Button,
+  Container,
+  Divider,
+  FormControl,
+  Grid,
+  Stack,
+  TextField,
+  ThemeProvider,
+  Typography,
+} from "@mui/material";
 import { theme } from "../styles/theme";
 import { useTheme } from "@mui/material/styles";
-import React, { useState } from 'react'
+import { ChangeEvent, useState } from "react";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 const Sigmaker: NextPage = () => {
@@ -13,17 +23,17 @@ const Sigmaker: NextPage = () => {
     fullName: "",
     title: "",
     phone: "",
-    email: ""
-  })
+    email: "",
+  });
 
-  const handleChange = e => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const name = e.target.name;
-    const value =
+    const value = e.target.value;
     setFormData({
       ...formData,
-      [name]: value
-    })
-  }
+      [name]: value,
+    });
+  };
 
   return (
     <ThemeProvider theme={theme}>
@@ -34,10 +44,10 @@ const Sigmaker: NextPage = () => {
         <Typography variant="h5"> Enter your info here! </Typography>
         <FormControl sx={{ my: 3 }}>
           <Stack spacing={3}>
-            <TextField 
-              name = "fullName" 
-              value= { formData.fullName } 
-              onChange = { handleChange }
+            <TextField
+              name="fullName"
+              value={formData.fullName}
+              onChange={handleChange}
               label="Full name"
               id="filled-size-small"
               variant="filled"
@@ -45,9 +55,9 @@ const Sigmaker: NextPage = () => {
               sx={{ width: "25ch" }}
             />
             <TextField
-              name = "title" 
-              value= { formData.title } 
-              onChange = { handleChange }
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
               label="Title"
               id="filled-size-small"
               variant="filled"
@@ -55,9 +65,9 @@ const Sigmaker: NextPage = () => {
               sx={{ width: "25ch" }}
             />
             <TextField
-              name = "phone" 
-              value= { formData.phone } 
-              onChange = { handleChange }            
+              name="phone"
+              value={formData.phone}
+              onChange={handleChange}
               label="Phone"
               id="filled-size-small"
               variant="filled"
@@ -66,10 +76,10 @@ const Sigmaker: NextPage = () => {
             />
             <Grid sx={{ display: isNotMobile ? "flex" : "block" }}>
               <TextField
-              name = "email" 
-              value= { formData.email } 
-              onChange = { handleChange }              
-                label="Email" 
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+                label="Email"
                 id="filled-size-small"
                 variant="filled"
                 size="small"
@@ -80,7 +90,14 @@ const Sigmaker: NextPage = () => {
           </Stack>
         </FormControl>
         <div>
-          <Button size="large" color="info" variant="contained">
+          <Button
+            size="large"
+            color="info"
+            variant="contained"
+            onClick={() =>
+              setFormData({ fullName: "", title: "", phone: "", email: "" })
+            }
+          >
             Generate signature!
           </Button>
         </div>

--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -1,9 +1,58 @@
 import type { NextPage } from "next";
+import { Button } from '@mui/material';
+import { Container } from '@mui/material';
+import { Divider } from "@mui/material";
+import { FormControl } from '@mui/material';
+import { Stack } from '@mui/material';
+import { TextField } from "@mui/material";
 import { ThemeProvider } from "@mui/material";
+import { Typography } from "@mui/material";
 import { theme } from "../styles/theme";
 
 const Sigmaker: NextPage = () => {
-  return <ThemeProvider theme={theme}></ThemeProvider>;
+  return (
+    <ThemeProvider theme={theme}>
+      <Container> 
+
+      <Typography variant="h3"> Signature Maker </Typography>
+      <Divider />
+      <Typography variant="body1"> Enter your info here! </Typography>
+      <FormControl sx={{ width: '25ch' }}> <Stack spacing={2}>
+      
+      <TextField
+          label="Full name"
+          id="filled-size-small"
+          variant="filled"
+          size="small"
+        />
+
+    
+      <TextField
+          label="Title"
+          id="filled-size-small"
+          variant="filled"
+          size="small"
+        /> 
+      <TextField
+          label="Phone"
+          id="filled-size-small"
+          variant="filled"
+          size="small"
+        /> 
+      
+        <Stack direction="row" spacing={1}>
+        <TextField
+          label="Email"
+          id="filled-size-small"
+          variant="filled"
+          size="small"
+        /> @hackbeanpot.com
+</Stack>
+    </Stack> </FormControl>  
+      <div> <Button size='medium' variant='contained'> Generate email signature! </Button> </div>
+      </Container> 
+    </ThemeProvider>
+  );
 };
 
 export default Sigmaker;

--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -4,21 +4,15 @@ import {
   Container,
   Divider,
   FormControl,
-  Grid,
   Stack,
   TextField,
   ThemeProvider,
   Typography,
 } from "@mui/material";
 import { theme } from "../styles/theme";
-import { useTheme } from "@mui/material/styles";
 import { ChangeEvent, useState } from "react";
-import useMediaQuery from "@mui/material/useMediaQuery";
 
 const Sigmaker: NextPage = () => {
-  const themeMUI = useTheme();
-  const isNotMobile = useMediaQuery(themeMUI.breakpoints.up("sm"));
-
   const [formData, setFormData] = useState({
     fullName: "",
     title: "",
@@ -35,6 +29,19 @@ const Sigmaker: NextPage = () => {
     });
   };
 
+  const createInputField = (name: string, value: string, label: string) => (
+    <TextField
+      name={name}
+      value={value}
+      onChange={handleChange}
+      label={label}
+      id="filled-size-small"
+      variant="filled"
+      size="small"
+      sx={{ width: "25ch" }}
+    />
+  );
+
   return (
     <ThemeProvider theme={theme}>
       <Container sx={{ mt: 4 }}>
@@ -44,49 +51,14 @@ const Sigmaker: NextPage = () => {
         <Typography variant="h5"> Enter your info here! </Typography>
         <FormControl sx={{ my: 3 }}>
           <Stack spacing={3}>
-            <TextField
-              name="fullName"
-              value={formData.fullName}
-              onChange={handleChange}
-              label="Full name"
-              id="filled-size-small"
-              variant="filled"
-              size="small"
-              sx={{ width: "25ch" }}
-            />
-            <TextField
-              name="title"
-              value={formData.title}
-              onChange={handleChange}
-              label="Title"
-              id="filled-size-small"
-              variant="filled"
-              size="small"
-              sx={{ width: "25ch" }}
-            />
-            <TextField
-              name="phone"
-              value={formData.phone}
-              onChange={handleChange}
-              label="Phone"
-              id="filled-size-small"
-              variant="filled"
-              size="small"
-              sx={{ width: "25ch" }}
-            />
-            <Grid sx={{ display: isNotMobile ? "flex" : "block" }}>
-              <TextField
-                name="email"
-                value={formData.email}
-                onChange={handleChange}
-                label="Email"
-                id="filled-size-small"
-                variant="filled"
-                size="small"
-                sx={{ width: "25ch" }}
-              />
-              <Typography sx={{ mt: 2, ml: 1 }}>@hackbeanpot.com</Typography>
-            </Grid>
+            {createInputField("fullName", formData.fullName, "Full name")}
+            {createInputField("title", formData.title, "Title")}
+            {createInputField("phone", formData.phone, "Phone")}
+            {createInputField(
+              "email",
+              formData.email,
+              "Email (@hackbeanpot.com)"
+            )}
           </Stack>
         </FormControl>
         <div>

--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -1,56 +1,68 @@
 import type { NextPage } from "next";
-import { Button } from '@mui/material';
-import { Container } from '@mui/material';
+import { Button } from "@mui/material";
+import { Container } from "@mui/material";
 import { Divider } from "@mui/material";
-import { FormControl } from '@mui/material';
-import { Stack } from '@mui/material';
+import { FormControl } from "@mui/material";
+import { Stack } from "@mui/material";
 import { TextField } from "@mui/material";
 import { ThemeProvider } from "@mui/material";
 import { Typography } from "@mui/material";
+import { Grid } from "@mui/material";
 import { theme } from "../styles/theme";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 const Sigmaker: NextPage = () => {
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.up("sm"));
   return (
     <ThemeProvider theme={theme}>
-      <Container> 
-
-      <Typography variant="h3"> Signature Maker </Typography>
-      <Divider />
-      <Typography variant="body1"> Enter your info here! </Typography>
-      <FormControl sx={{ width: '25ch' }}> <Stack spacing={2}>
-      
-      <TextField
-          label="Full name"
-          id="filled-size-small"
-          variant="filled"
-          size="small"
-        />
-
-    
-      <TextField
-          label="Title"
-          id="filled-size-small"
-          variant="filled"
-          size="small"
-        /> 
-      <TextField
-          label="Phone"
-          id="filled-size-small"
-          variant="filled"
-          size="small"
-        /> 
-      
-        <Stack direction="row" spacing={1}>
-        <TextField
-          label="Email"
-          id="filled-size-small"
-          variant="filled"
-          size="small"
-        /> @hackbeanpot.com
-</Stack>
-    </Stack> </FormControl>  
-      <div> <Button size='medium' variant='contained'> Generate email signature! </Button> </div>
-      </Container> 
+      <Container sx={{ mt: 4 }}>
+        <Typography variant="h3"> Signature Maker </Typography>
+        <Divider />
+        <br />
+        <Typography variant="h5"> Enter your info here! </Typography>
+        <FormControl sx={{ my: 3 }}>
+          <Stack spacing={3}>
+            <TextField
+              label="Full name"
+              id="filled-size-small"
+              variant="filled"
+              size="small"
+              sx={{ width: "25ch" }}
+            />
+            <TextField
+              label="Title"
+              id="filled-size-small"
+              variant="filled"
+              size="small"
+              sx={{ width: "25ch" }}
+            />
+            <TextField
+              label="Phone"
+              id="filled-size-small"
+              variant="filled"
+              size="small"
+              sx={{ width: "25ch" }}
+            />
+            <Grid sx={{ display: matches ? "flex" : "block" }}>
+              <TextField
+                label="Email" 
+                id="filled-size-small"
+                variant="filled"
+                size="small"
+                sx={{ width: "25ch" }}
+              />
+              <Typography sx={{ mt: 2, ml: 1 }}>@hackbeanpot.com</Typography>
+            </Grid>
+          </Stack>
+        </FormControl>
+        <div>
+          <Button size="large" color="info" variant="contained">
+            Generate signature!
+          </Button>
+        </div>
+      </Container>
     </ThemeProvider>
   );
 };

--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -1,20 +1,30 @@
 import type { NextPage } from "next";
-import { Button } from "@mui/material";
-import { Container } from "@mui/material";
-import { Divider } from "@mui/material";
-import { FormControl } from "@mui/material";
-import { Stack } from "@mui/material";
-import { TextField } from "@mui/material";
-import { ThemeProvider } from "@mui/material";
-import { Typography } from "@mui/material";
-import { Grid } from "@mui/material";
+import { Button, Container, Divider, FormControl, Grid, Stack, TextField, ThemeProvider, Typography} from "@mui/material";
 import { theme } from "../styles/theme";
 import { useTheme } from "@mui/material/styles";
+import React, { useState } from 'react'
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 const Sigmaker: NextPage = () => {
   const themeMUI = useTheme();
-  const matches = useMediaQuery(themeMUI.breakpoints.up("sm"));
+  const isNotMobile = useMediaQuery(themeMUI.breakpoints.up("sm"));
+
+  const [formData, setFormData] = useState({
+    fullName: "",
+    title: "",
+    phone: "",
+    email: ""
+  })
+
+  const handleChange = e => {
+    const name = e.target.name;
+    const value =
+    setFormData({
+      ...formData,
+      [name]: value
+    })
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <Container sx={{ mt: 4 }}>
@@ -24,7 +34,10 @@ const Sigmaker: NextPage = () => {
         <Typography variant="h5"> Enter your info here! </Typography>
         <FormControl sx={{ my: 3 }}>
           <Stack spacing={3}>
-            <TextField
+            <TextField 
+              name = "fullName" 
+              value= { formData.fullName } 
+              onChange = { handleChange }
               label="Full name"
               id="filled-size-small"
               variant="filled"
@@ -32,6 +45,9 @@ const Sigmaker: NextPage = () => {
               sx={{ width: "25ch" }}
             />
             <TextField
+              name = "title" 
+              value= { formData.title } 
+              onChange = { handleChange }
               label="Title"
               id="filled-size-small"
               variant="filled"
@@ -39,14 +55,20 @@ const Sigmaker: NextPage = () => {
               sx={{ width: "25ch" }}
             />
             <TextField
+              name = "phone" 
+              value= { formData.phone } 
+              onChange = { handleChange }            
               label="Phone"
               id="filled-size-small"
               variant="filled"
               size="small"
               sx={{ width: "25ch" }}
             />
-            <Grid sx={{ display: matches ? "flex" : "block" }}>
+            <Grid sx={{ display: isNotMobile ? "flex" : "block" }}>
               <TextField
+              name = "email" 
+              value= { formData.email } 
+              onChange = { handleChange }              
                 label="Email" 
                 id="filled-size-small"
                 variant="filled"

--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -13,8 +13,8 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 const Sigmaker: NextPage = () => {
-  const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.up("sm"));
+  const themeMUI = useTheme();
+  const matches = useMediaQuery(themeMUI.breakpoints.up("sm"));
   return (
     <ThemeProvider theme={theme}>
       <Container sx={{ mt: 4 }}>


### PR DESCRIPTION
Closes [#3](https://github.com/HackBeanpot/internal-tools/issues/3). 

Updates the tech stack used to create the front-end of our internal signature tool with the following steps:

- Recreated signature form on /sigmaker
- Added logic to clear the form after the button is clicked
- Added logic to update the form data state that stores all the field values, and clear upon signature generation
- Made responsive from mobile -> desktop

Desktop view: 
![Desktop](https://user-images.githubusercontent.com/53664026/170417029-17c5fc4d-7a5e-4143-9412-ba7296ba0161.png)

Mobile view:
![Mobile](https://user-images.githubusercontent.com/53664026/170417010-9928dff2-5dec-489d-97a6-c86568628f64.png)
