### PR TITLE
Tool home page v3 with react 

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css'
+import "../styles/home.css"
 import type { AppProps } from 'next/app'
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,15 @@
+import { ThemeProvider, Divider, Typography, Link } from "@mui/material";
 import type { NextPage } from "next";
-import { ThemeProvider } from "@mui/material";
 import { theme } from "../styles/theme";
-import { Divider } from "@mui/material";
-import { Typography } from "@mui/material";
-import Link from "@mui/material/Link";
+
 
 const Home: NextPage = () => {
   return (
     <ThemeProvider theme={theme}>
       <div className="tool-box">
-        <h3>Tools</h3>
+      <Typography variant="h3" component="h3">
+        Tools
+        </Typography>
         <Divider light />
         <Typography variant="body1" component="p">
           🛠 Internal tools + useful things for core members like…
@@ -17,13 +17,11 @@ const Home: NextPage = () => {
         <Typography variant="body1" component="ul">
           <li>
             <Link
-              href="https://tools.hackbeanpot.com/sigmaker/"
-              target="_blank"
+              href="/sigmaker"
               underline="hover"
             >
-              An email signature generator{" "}
+              An email signature generator
             </Link>
-            (last updated September 2019)
           </li>
         </Typography>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,34 @@
 import type { NextPage } from "next";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "../styles/theme";
+import { Divider } from "@mui/material";
+import { Typography } from "@mui/material";
+import Link from "@mui/material/Link";
 
 const Home: NextPage = () => {
-  return <ThemeProvider theme={theme}></ThemeProvider>;
+  return (
+    <ThemeProvider theme={theme}>
+      <div className="tool-box">
+        <h3>Tools</h3>
+        <Divider light />
+        <Typography variant="body1" component="p">
+          🛠 Internal tools + useful things for core members like…
+        </Typography>
+        <Typography variant="body1" component="ul">
+          <li>
+            <Link
+              href="https://tools.hackbeanpot.com/sigmaker/"
+              target="_blank"
+              underline="hover"
+            >
+              An email signature generator{" "}
+            </Link>
+            (last updated September 2019)
+          </li>
+        </Typography>
+      </div>
+    </ThemeProvider>
+  );
 };
 
 export default Home;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,19 +15,7 @@ a {
   box-sizing: border-box;
 }
 
-h3 {
-  font-size: 2em;
-  margin-bottom: 20px;
-}
 
-.MuiTypography-body1 {
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
 
-.tool-box {
-  margin-top: 50px;
-  margin-left: 10%;
-  margin-right: 10%;
-}
+
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,3 +14,20 @@ a {
 * {
   box-sizing: border-box;
 }
+
+h3 {
+  font-size: 2em;
+  margin-bottom: 20px;
+}
+
+.MuiTypography-body1 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.tool-box {
+  margin-top: 50px;
+  margin-left: 10%;
+  margin-right: 10%;
+}
+

--- a/styles/home.css
+++ b/styles/home.css
@@ -1,0 +1,10 @@
+.MuiTypography-body1 {
+    margin: 16px 0;
+  }
+
+.tool-box {
+    margin-top: 50px;
+    margin-left: 10%;
+    margin-right: 10%;
+  }
+


### PR DESCRIPTION
Addressing Issue #4 

Updated the tech stack for internal tools homepage using react

- Used h3 typography for "Tools" title 
- Used body1 typography for " 🛠 Internal tools + useful things for core members like…" and the unordered list of tools.
- Added mouseover functionality for email generator tool link.
- Wrapped all components in a div
- Styled margins of .tool-box div and .MuiTypography-body1 to mimic old site and allow for responsiveness for mobile to desktop in home.css
- Removed "(last updated September 2019)"
- Removed constants.css

Mobile View
<img width="640" alt="Screen Shot 2022-05-26 at 5 30 29 PM" src="https://user-images.githubusercontent.com/103906123/170583377-0f54097b-319e-4739-b365-d522af689d54.png">

Tablet View
<img width="980" alt="Screen Shot 2022-05-26 at 5 31 41 PM" src="https://user-images.githubusercontent.com/103906123/170583526-6bed3a68-0735-4ee6-8c0b-82f0541ddc27.png">

Desktop View 
<img width="1800" alt="Screen Shot 2022-05-26 at 5 44 01 PM" src="https://user-images.githubusercontent.com/103906123/170585025-0cf7a2ef-1bf4-46f2-8f9d-0e802fb26bab.png">





