### PR TITLE
Link Error and CSS fix

### DIFF
--- a/pages/sigmaker.tsx
+++ b/pages/sigmaker.tsx
@@ -13,6 +13,7 @@ import {
 import { theme } from "../styles/theme";
 import { ChangeEvent, useState } from "react";
 import { icons } from "../styles/icons"
+import Link from "next/link";
 
 interface SignatureData {
   fullName: string
@@ -64,7 +65,7 @@ const Sigmaker: NextPage = () => {
               <tbody>
                 <tr>
                   <td valign="top" className="logoContainer">
-                    <img className="logo" id="preview-image-url" src={icons.HBP_LOGO.image} />
+                    <img className="logo" id="preview-image-url" src={icons.HBP_LOGO.image} alt={icons.HBP_LOGO.altText}/>
                   </td>
                   <td className="contentContainer">
                     <table cellPadding={0} cellSpacing={0} className="table">
@@ -85,9 +86,9 @@ const Sigmaker: NextPage = () => {
                         </tr>
                         <tr>
                           <td valign="top" className="linkContainer">
-                            <a href="https://hackbeanpot.com" className="link" target="_blank">
+                            <Link href="https://hackbeanpot.com" className="link" target="_blank">
                               www.hackbeanpot.com
-                            </a>
+                            </Link>
                           </td>
                         </tr>
                         <tr>

--- a/styles/home.css
+++ b/styles/home.css
@@ -1,5 +1,5 @@
 .MuiTypography-body1 {
-    margin: 16px 0;
+    margin: 16px 0 !important;
   }
 
 .tool-box {


### PR DESCRIPTION
This PR contains: 
- Fix for this error when deploying to vercel by switching to using Link from next.js <img width="622" alt="Screen Shot 2022-06-05 at 11 45 14 AM" src="https://user-images.githubusercontent.com/59738880/172058806-ea5837c4-951a-4815-b055-6967168cef40.png">
- In a production build, the some of the CSS on the home page was not loading b/c of MUI styling so I overrode it <img width="1482" alt="Screen Shot 2022-06-05 at 12 16 20 PM" src="https://user-images.githubusercontent.com/59738880/172060087-a3e6d50f-ab05-41af-b475-d65f7971b4eb.png">
- Added in the alt text for hbp logo image for accessibility
