### PR TITLE
Whitespace ds

### DIFF
--- a/pageStyles/emailSender.styles.ts
+++ b/pageStyles/emailSender.styles.ts
@@ -33,6 +33,10 @@ const StyledTableContainer = styled('div')({
   marginBottom: 50
 })
 
+const StyledFinalMessageContent = styled('div')({
+  whiteSpace: 'pre-wrap'
+})
+
 const StyledDivider = styled(Divider)({
   marginTop: 50,
   marginBottom: 50
@@ -48,5 +52,6 @@ const StyledTableRow = styled(TableRow)({
 
 export {
   SectionContainer, StyledTextArea, StyledCsvButton, StyledCsvButtonsContainer, StyledSubHeader,
-  StyledFinalMessagesContainer, StyledTableContainer, StyledDivider, StyledTable, StyledTableRow
+  StyledFinalMessagesContainer, StyledTableContainer, StyledDivider, StyledTable, StyledTableRow,
+  StyledFinalMessageContent
 }

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -31,7 +31,8 @@ import {
   StyledTableContainer,
   StyledDivider,
   StyledTable,
-  StyledTableRow
+  StyledTableRow,
+  StyledFinalMessageContent
 } from '../pageStyles/emailSender.styles'
 
 const EmailSender: NextPage = () => {
@@ -63,8 +64,7 @@ const EmailSender: NextPage = () => {
     let allRowValues = str.slice(str.indexOf('\n') + 1).split('\n')
     allRowValues = allRowValues.map((string) => {
       return string.trim()
-    });
-    console.log(allRowValues)
+    })
     const allRowObjects = allRowValues.map((i) => {
       const currRowValues = i.split(',')
       const currRowObject = csvHeaders.reduce(
@@ -152,7 +152,10 @@ const EmailSender: NextPage = () => {
             <br />
             <Typography variant="body1">Content:</Typography>
             <br />
-            <Typography variant="body1">{msg.content}</Typography>
+            <Typography variant="body1">
+              <StyledFinalMessageContent>{msg.content}</StyledFinalMessageContent>
+            </Typography>
+
           </div>
         ))}
       </>

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -60,7 +60,11 @@ const EmailSender: NextPage = () => {
 
   const csvFileToArray = (str: string) => {
     const csvHeaders = str.slice(0, str.indexOf('\n')).split(',')
-    const allRowValues = str.slice(str.indexOf('\n') + 1).split('\n')
+    let allRowValues = str.slice(str.indexOf('\n') + 1).split('\n')
+    allRowValues = allRowValues.map((string) => {
+      return string.trim()
+    });
+    console.log(allRowValues)
     const allRowObjects = allRowValues.map((i) => {
       const currRowValues = i.split(',')
       const currRowObject = csvHeaders.reduce(


### PR DESCRIPTION
Closes #20 

Updated the code to handle whitespaces correctly in two cases. 

1. Retain the whitespaces when displaying the messages. 
        - Added a styled div with the CSS whitespace on pre-wrap
        - Used this styled div when displaying the content of the final message. 
![image](https://user-images.githubusercontent.com/65351416/175023740-e2f1732f-2abd-4134-9484-3932fe8e8cb1.png)

2.  Trim out the extra spaces from info obtained from the csv
        - Used a map on allRowValues and stripped whitespace using .trim() on all csv inputs.
![image](https://user-images.githubusercontent.com/65351416/175024151-0bc8b7ee-c70f-419b-a8f6-6944f3c2e897.png)
