### PR TITLE
Editable messages

### DIFF
--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react'
 import { Typography, Button } from '@mui/material'
 
 import { StyledFinalMessageContent, StyledTextArea } from '../../pageStyles/emailSender.styles'
-
 type FinalMessageProps = {
     id: string,
     to: string,
@@ -55,6 +54,7 @@ export default function FinalMessage
 
                         </StyledTextArea>
                         <Button
+                            color="success"
                             variant="contained"
                             size="small"
                             onClick={handleSubmitButton}
@@ -69,6 +69,7 @@ export default function FinalMessage
                             {messageContent}
                         </StyledFinalMessageContent>
                         <Button
+                            color="primary"
                             variant="contained"
                             size="small"
                             onClick={handleEditButton}

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -53,8 +53,8 @@ export default function FinalMessage
                         <StyledTextArea
                             value={messageContent}
                             id="outlined-basic"
-                            onChange={handleEditMessage}>
-                        </StyledTextArea>
+                            onChange={handleEditMessage}
+                        />
                     </div>
 
                   : <div>

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import { Typography, Button } from '@mui/material'
 
-import { StyledFinalMessageContent, StyledTextField } from '../../pageStyles/emailSender.styles'
+import { StyledFinalMessageContent, StyledTextArea } from '../../pageStyles/emailSender.styles'
 
 type FinalMessageProps = {
     id: string,
@@ -46,14 +46,14 @@ export default function FinalMessage
 
                 {isEditing
                   ? <div>
-                        <StyledTextField
+                        <StyledTextArea
                             value={messageContent}
                             id="outlined-basic"
                             label="Email subject"
                             variant="outlined"
                             onChange={handleEditMessage}>
 
-                        </StyledTextField>
+                        </StyledTextArea>
                         <Button
                             variant="contained"
                             size="small"

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -14,7 +14,6 @@ type FinalMessageProps = {
 
 export default function FinalMessage
 ({ id, to, subject, content, parentCallback }: FinalMessageProps) {
-  console.log(parentCallback)
   const toMessage = to
   const subjectMessage = subject
   const idMail = id
@@ -32,11 +31,12 @@ export default function FinalMessage
 
   const handleSubmitButton = () => {
     setIsEditing(false)
-    parentCallback(id, messageContent)
+    console.log(idMail)
+    parentCallback(idMail, to, subject, messageContent)
   }
 
   return (
-        <div id={idMail}>
+        <div>
             <Typography variant="body1">To:{toMessage}</Typography>
             <Typography variant="body1">Subject: {subjectMessage}</Typography>
             <br />

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -1,0 +1,67 @@
+import React, { ChangeEvent, useState } from 'react'
+
+import { Typography, Button } from '@mui/material';
+
+import { StyledFinalMessageContent, StyledTextField } from '../../pageStyles/emailSender.styles'
+
+
+type FinalMessageProps = {
+    id: string,
+    to: string,
+    subject: string,
+    content: string
+};
+
+export default function FinalMessage({ id, to, subject, content }: FinalMessageProps) {
+    const toMessage = to
+    const subjectMessage = subject
+    const idMail = id
+    const contentMessage = content
+
+
+    const [isEditing, setIsEditing] = useState(false)
+    const [messageContent, setMessageContent] = useState(content)
+
+
+    const handleEditButton = () => {
+        setIsEditing(true)
+        
+    }
+
+    const handleEditMessage = (e: any) => {
+        setMessageContent(e.target.value)
+    }
+
+
+    return (
+        <div id={idMail}>
+            <Typography variant="body1">To:{toMessage}</Typography>
+            <Typography variant="body1">Subject: {subjectMessage}</Typography>
+            <br />
+            <Typography variant="body1">Content:</Typography>
+            <br />
+            <Typography variant="body1">
+
+                {isEditing ?
+                    <StyledTextField
+                        value={messageContent}
+                        id="outlined-basic"
+                        label="Email subject"
+                        variant="outlined"
+                        onChange={handleEditMessage}>
+                    </StyledTextField>:
+                     <StyledFinalMessageContent>
+                        <Button
+                        variant="contained"
+                        onClick={}
+                        >
+
+                        </Button>
+
+                        {messageContent}
+                     </StyledFinalMessageContent>
+                }
+            </Typography>
+        </div>
+    )
+}

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -1,39 +1,41 @@
-import React, { ChangeEvent, useState } from 'react'
+import React, { useState } from 'react'
 
-import { Typography, Button } from '@mui/material';
+import { Typography, Button } from '@mui/material'
 
 import { StyledFinalMessageContent, StyledTextField } from '../../pageStyles/emailSender.styles'
-
 
 type FinalMessageProps = {
     id: string,
     to: string,
     subject: string,
-    content: string
+    content: string,
+    parentCallback: Function,
 };
 
-export default function FinalMessage({ id, to, subject, content }: FinalMessageProps) {
-    const toMessage = to
-    const subjectMessage = subject
-    const idMail = id
-    const contentMessage = content
+export default function FinalMessage
+({ id, to, subject, content, parentCallback }: FinalMessageProps) {
+  console.log(parentCallback)
+  const toMessage = to
+  const subjectMessage = subject
+  const idMail = id
 
+  const [isEditing, setIsEditing] = useState(false)
+  const [messageContent, setMessageContent] = useState(content)
 
-    const [isEditing, setIsEditing] = useState(false)
-    const [messageContent, setMessageContent] = useState(content)
+  const handleEditButton = () => {
+    setIsEditing(true)
+  }
 
+  const handleEditMessage = (e: any) => {
+    setMessageContent(e.target.value)
+  }
 
-    const handleEditButton = () => {
-        setIsEditing(true)
-        
-    }
+  const handleSubmitButton = () => {
+    setIsEditing(false)
+    parentCallback(id, messageContent)
+  }
 
-    const handleEditMessage = (e: any) => {
-        setMessageContent(e.target.value)
-    }
-
-
-    return (
+  return (
         <div id={idMail}>
             <Typography variant="body1">To:{toMessage}</Typography>
             <Typography variant="body1">Subject: {subjectMessage}</Typography>
@@ -42,26 +44,41 @@ export default function FinalMessage({ id, to, subject, content }: FinalMessageP
             <br />
             <Typography variant="body1">
 
-                {isEditing ?
-                    <StyledTextField
-                        value={messageContent}
-                        id="outlined-basic"
-                        label="Email subject"
-                        variant="outlined"
-                        onChange={handleEditMessage}>
-                    </StyledTextField>:
-                     <StyledFinalMessageContent>
+                {isEditing
+                  ? <div>
+                        <StyledTextField
+                            value={messageContent}
+                            id="outlined-basic"
+                            label="Email subject"
+                            variant="outlined"
+                            onChange={handleEditMessage}>
+
+                        </StyledTextField>
                         <Button
-                        variant="contained"
-                        onClick={}
+                            variant="contained"
+                            size="small"
+                            onClick={handleSubmitButton}
                         >
-
+                            Save
                         </Button>
+                    </div>
 
-                        {messageContent}
-                     </StyledFinalMessageContent>
+                  : <div>
+                        <StyledFinalMessageContent>
+
+                            {messageContent}
+                        </StyledFinalMessageContent>
+                        <Button
+                            variant="contained"
+                            size="small"
+                            onClick={handleEditButton}
+                        >
+                            Edit
+                        </Button>
+                    </div>
+
                 }
             </Typography>
         </div>
-    )
+  )
 }

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
+import { Typography } from '@mui/material'
+import { StyledEditButton, StyledFinalMessageContent, StyledTextArea } from '../../styles/common'
 
-import { Typography, Button } from '@mui/material'
-
-import { StyledFinalMessageContent, StyledTextArea } from '../../pageStyles/emailSender.styles'
 type FinalMessageProps = {
     id: string,
     to: string,
@@ -30,13 +29,19 @@ export default function FinalMessage
 
   const handleSubmitButton = () => {
     setIsEditing(false)
-    console.log(idMail)
     parentCallback(idMail, to, subject, messageContent)
   }
 
   return (
-        <div>
-            <Typography variant="body1">To:{toMessage}</Typography>
+    <>
+            <StyledEditButton
+                variant="contained"
+                size="small"
+                onClick={isEditing ? handleSubmitButton : handleEditButton}
+            >
+                {isEditing ? 'Save' : 'Edit'}
+            </StyledEditButton>
+            <Typography variant="body1">To: {toMessage}</Typography>
             <Typography variant="body1">Subject: {subjectMessage}</Typography>
             <br />
             <Typography variant="body1">Content:</Typography>
@@ -48,19 +53,8 @@ export default function FinalMessage
                         <StyledTextArea
                             value={messageContent}
                             id="outlined-basic"
-                            label="Email subject"
-                            variant="outlined"
                             onChange={handleEditMessage}>
-
                         </StyledTextArea>
-                        <Button
-                            color="success"
-                            variant="contained"
-                            size="small"
-                            onClick={handleSubmitButton}
-                        >
-                            Save
-                        </Button>
                     </div>
 
                   : <div>
@@ -68,18 +62,10 @@ export default function FinalMessage
 
                             {messageContent}
                         </StyledFinalMessageContent>
-                        <Button
-                            color="primary"
-                            variant="contained"
-                            size="small"
-                            onClick={handleEditButton}
-                        >
-                            Edit
-                        </Button>
                     </div>
 
                 }
             </Typography>
-        </div>
+            </>
   )
 }

--- a/pageStyles/emailSender.styles.ts
+++ b/pageStyles/emailSender.styles.ts
@@ -1,4 +1,4 @@
-import { Divider, Table, TableRow, TextareaAutosize, TextField, Typography } from '@mui/material'
+import { Divider, Table, TableRow, TextField, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { StyledButton } from '../styles/common'
 import { theme } from '../styles/theme'
@@ -27,10 +27,6 @@ const StyledFinalMessagesContainer = styled('div')({
   marginBottom: 50
 })
 
-const StyledFinalMessageContent = styled('div')({
-  whiteSpace: 'pre-wrap'
-})
-
 const StyledSubHeader = styled(Typography)({
   paddingBottom: 25
 })
@@ -43,10 +39,6 @@ const StyledTableRow = styled(TableRow)({
   '&:last-child td, &:last-child th': {
     border: 0
   }
-})
-
-const StyledTextArea = styled(TextareaAutosize)({
-  width: '100%'
 })
 
 const StyledTextField = styled(TextField)({
@@ -69,7 +61,7 @@ const StyledResultMessage = styled(Typography, {
 }))
 
 export {
-  SectionContainer, StyledTextArea, StyledTextField, StyledCsvButton, StyledCsvButtonsContainer,
+  SectionContainer, StyledTextField, StyledCsvButton, StyledCsvButtonsContainer,
   StyledSubHeader, StyledFinalMessagesContainer, StyledTableContainer, StyledDivider,
-  StyledTable, StyledTableRow, StyledFinalMessageContent, StyledErrorMessage, StyledResultMessage
+  StyledTable, StyledTableRow, StyledErrorMessage, StyledResultMessage
 }

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -26,7 +26,9 @@ import {
   StyledButton,
   StyledPageContainer,
   StyledBoldTypograhy,
-  SectionContainer
+  SectionContainer,
+  StyledTextArea
+
 } from '../styles/common'
 import {
   CsvRow,
@@ -46,8 +48,7 @@ import {
   StyledTable,
   StyledTableContainer,
   StyledTableRow,
-  StyledTextField,
-  StyledTextArea
+  StyledTextField
 } from '../pageStyles/emailSender.styles'
 import Layout from '../components/layout/Layout'
 import FinalMessage from '../components/finalMessage/finalMessage'
@@ -75,14 +76,12 @@ const EmailSender: NextPage = () => {
       : setSubjectCustomization(true)
   }
 
-  const parentCallback = (id: string, to: string, subject: string, messageContent : string) => {
+  const editFinalMessages = (id: string, to: string, subject: string, messageContent: string) => {
     const finalMessageArr = []
     const content = messageContent
-    console.log(content)
     const finalMessageIndex = finalMessages.findIndex(finalMessage => {
       return finalMessage.id === id
     })
-    console.log(finalMessageIndex)
     for (let i = 0; i < finalMessages.length; i++) {
       if (i === finalMessageIndex) {
         const msg: Message = { id, to, subject, content }
@@ -240,19 +239,19 @@ const EmailSender: NextPage = () => {
       <>
         {finalMessages.map((msg) => (
           <div key={nanoid()}>
-          <StyledDivider/>
+            <StyledDivider />
             {getErrorMessage(msg.id) && (
               <StyledErrorMessage>
                 Error: {getErrorMessage(msg.id)}
               </StyledErrorMessage>
             )}
             <FinalMessage
-            id={msg.id}
-            to={msg.to}
-            subject={msg.subject}
-            parentCallback={parentCallback}
-            content={msg.content}>
-            </FinalMessage>
+              id={msg.id}
+              to={msg.to}
+              subject={msg.subject}
+              parentCallback={editFinalMessages}
+              content={msg.content}
+            />
           </div>
         ))}
       </>
@@ -291,7 +290,6 @@ const EmailSender: NextPage = () => {
   }
 
   const handleClickOpen = () => {
-    console.log(finalMessages)
     setOpen(true)
   }
   const handleClose = () => {
@@ -309,42 +307,42 @@ const EmailSender: NextPage = () => {
             <Link href="/emailSenderHelp" underline="hover">
               Help Page
             </Link>
-        </Typography>
-        <FormControl fullWidth>
-          <SectionContainer>
-            <StyledSubHeader variant="h5">
-              1) Email subject
-            </StyledSubHeader>
-            <FormLabel id="choose-email-subject">
-              Use customized or standard email subjects?
-            </FormLabel>
-            <RadioGroup
-              aria-labelledby="choose-email-subject"
-              name="email-subject"
-              onChange={handleEmailStandard}
-            >
-              <FormControlLabel value="customized" control={<Radio />}
-              label="Customized (add subjects from CSV)" />
-              <FormControlLabel value="standard" control={<Radio />}
-              label="Standard (enter one subject for all emails)" />
-            </RadioGroup>
-            <br />
-          </SectionContainer>
-          <SectionContainer>
-            <div>{printStandardEmailSubject()}</div>
-          </SectionContainer>
-          <SectionContainer>
-            <StyledSubHeader variant="h5">
-              2) Enter email content
-            </StyledSubHeader>
-            <StyledTextArea
-              aria-label="message-text-area"
-              placeholder="Paste in message"
-              onChange={(e) => setMessage(e.target.value)}
-              minRows={20}
-            />
-          </SectionContainer>
-          <SectionContainer>
+          </Typography>
+          <FormControl fullWidth>
+            <SectionContainer>
+              <StyledSubHeader variant="h5">
+                1) Email subject
+              </StyledSubHeader>
+              <FormLabel id="choose-email-subject">
+                Use customized or standard email subjects?
+              </FormLabel>
+              <RadioGroup
+                aria-labelledby="choose-email-subject"
+                name="email-subject"
+                onChange={handleEmailStandard}
+              >
+                <FormControlLabel value="customized" control={<Radio />}
+                  label="Customized (add subjects from CSV)" />
+                <FormControlLabel value="standard" control={<Radio />}
+                  label="Standard (enter one subject for all emails)" />
+              </RadioGroup>
+              <br />
+            </SectionContainer>
+            <SectionContainer>
+              <div>{printStandardEmailSubject()}</div>
+            </SectionContainer>
+            <SectionContainer>
+              <StyledSubHeader variant="h5">
+                2) Enter email content
+              </StyledSubHeader>
+              <StyledTextArea
+                aria-label="message-text-area"
+                placeholder="Paste in message"
+                onChange={(e) => setMessage(e.target.value)}
+                minRows={20}
+              />
+            </SectionContainer>
+            <SectionContainer>
               <StyledSubHeader variant="h5">
                 3) Upload and import csv
               </StyledSubHeader>
@@ -371,7 +369,7 @@ const EmailSender: NextPage = () => {
                 >
                   Import CSV!
                 </StyledCsvButton>
-                </StyledCsvButtonsContainer>
+              </StyledCsvButtonsContainer>
             </SectionContainer>
           </FormControl>
           <StyledTableContainer>

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -41,7 +41,6 @@ import {
   StyledDivider,
   StyledErrorMessage,
   StyledFinalMessagesContainer,
-  StyledFinalMessageContent,
   StyledResultMessage,
   StyledSubHeader,
   StyledTable,
@@ -51,6 +50,7 @@ import {
   StyledTextArea
 } from '../pageStyles/emailSender.styles'
 import Layout from '../components/layout/Layout'
+import FinalMessage from '../components/finalMessage/finalMessage'
 import { GetServerSideProps } from 'next'
 import { getServerSideSessionOrRedirect } from '../server/getServerSideSessionOrRedirect'
 
@@ -73,6 +73,22 @@ const EmailSender: NextPage = () => {
     (e.target.value === 'standard')
       ? setSubjectCustomization(false)
       : setSubjectCustomization(true)
+  }
+
+  const parentCallback = (id: string, to: string, subject: string, messageContent : string) => {
+    const finalMessageArr = []
+    const finalMessageIndex = finalMessages.findIndex(finalMessage => {
+      finalMessage.id === id
+    })
+    for (let i = 0; i < finalMessages.length; i++) {
+      if (i === finalMessageIndex) {
+        const msg: Message = { id, to, subject, messageContent }
+        finalMessageArr.push(msg)
+      } else {
+        finalMessageArr.push(finalMessages[i])
+      }
+    }
+    setFinalMessages(finalMessageArr)
   }
 
   const printStandardEmailSubject = () => {
@@ -220,26 +236,20 @@ const EmailSender: NextPage = () => {
     return (
       <>
         {finalMessages.map((msg) => (
-          <div key={nanoid()}>
-            <StyledDivider />
+          <StyledDivider key={nanoid()}>
             {getErrorMessage(msg.id) && (
               <StyledErrorMessage>
                 Error: {getErrorMessage(msg.id)}
               </StyledErrorMessage>
             )}
-            <br />
-            <br />
-            <Typography variant="body1">To: {msg.to}</Typography>
-            <Typography variant="body1">Subject: {msg.subject}</Typography>
-            <br />
-            <Typography variant="body1">Content:</Typography>
-            <br />
-            <Typography variant="body1">
-              <StyledFinalMessageContent>
-                {msg.content}
-              </StyledFinalMessageContent>
-            </Typography>
-          </div>
+            <FinalMessage
+            id={nanoid()}
+            to={msg.to}
+            subject={msg.subject}
+            parentCallback={parentCallback}
+            content={msg.content}>
+            </FinalMessage>
+          </StyledDivider>
         ))}
       </>
     )
@@ -277,7 +287,7 @@ const EmailSender: NextPage = () => {
   }
 
   const handleClickOpen = () => {
-    console.log('HERE')
+    console.log(finalMessages)
     setOpen(true)
   }
   const handleClose = () => {

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -79,9 +79,7 @@ const EmailSender: NextPage = () => {
     const finalMessageArr = []
     const content = messageContent
     console.log(content)
-    // eslint-disable-next-line array-callback-return
     const finalMessageIndex = finalMessages.findIndex(finalMessage => {
-      // eslint-disable-next-line no-unused-expressions
       return finalMessage.id === id
     })
     console.log(finalMessageIndex)

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -77,12 +77,17 @@ const EmailSender: NextPage = () => {
 
   const parentCallback = (id: string, to: string, subject: string, messageContent : string) => {
     const finalMessageArr = []
+    const content = messageContent
+    console.log(content)
+    // eslint-disable-next-line array-callback-return
     const finalMessageIndex = finalMessages.findIndex(finalMessage => {
-      finalMessage.id === id
+      // eslint-disable-next-line no-unused-expressions
+      return finalMessage.id === id
     })
+    console.log(finalMessageIndex)
     for (let i = 0; i < finalMessages.length; i++) {
       if (i === finalMessageIndex) {
-        const msg: Message = { id, to, subject, messageContent }
+        const msg: Message = { id, to, subject, content }
         finalMessageArr.push(msg)
       } else {
         finalMessageArr.push(finalMessages[i])
@@ -236,20 +241,21 @@ const EmailSender: NextPage = () => {
     return (
       <>
         {finalMessages.map((msg) => (
-          <StyledDivider key={nanoid()}>
+          <div key={nanoid()}>
+          <StyledDivider/>
             {getErrorMessage(msg.id) && (
               <StyledErrorMessage>
                 Error: {getErrorMessage(msg.id)}
               </StyledErrorMessage>
             )}
             <FinalMessage
-            id={nanoid()}
+            id={msg.id}
             to={msg.to}
             subject={msg.subject}
             parentCallback={parentCallback}
             content={msg.content}>
             </FinalMessage>
-          </StyledDivider>
+          </div>
         ))}
       </>
     )

--- a/styles/common.ts
+++ b/styles/common.ts
@@ -1,5 +1,5 @@
 import { styled } from '@mui/system'
-import { Button, Container, Typography } from '@mui/material'
+import { Button, Container, TextareaAutosize, Typography } from '@mui/material'
 import { theme } from './theme'
 
 const StyledPageContainer = styled(Container)({
@@ -28,4 +28,19 @@ const SectionContainer = styled('div')({
   marginBottom: 30
 })
 
-export { StyledPageContainer, StyledButton, StyledBoldTypograhy, SectionContainer }
+const StyledTextArea = styled(TextareaAutosize)({
+  width: '100%'
+})
+
+const StyledEditButton = styled(Button)({
+  float: 'right'
+})
+
+const StyledFinalMessageContent = styled('div')({
+  whiteSpace: 'pre-wrap'
+})
+
+export {
+  StyledPageContainer, StyledButton, StyledBoldTypograhy, SectionContainer, StyledTextArea,
+  StyledFinalMessageContent, StyledEditButton
+}


### PR DESCRIPTION
Closes #47 

- The preview messages are now editable.
-  When the edit button is clicked it switches to an editable text area and the edit button changes to save. 
- The messages are sent with the updated content. 

Before 
![Capture213](https://user-images.githubusercontent.com/65351416/179292682-a72845e0-333e-49a3-9d7f-9e37763d5080.PNG)

During edit
![Capture123](https://user-images.githubusercontent.com/65351416/179292754-ccc7819a-cf95-4bf9-84bd-a028408f5f76.PNG)
 
Saved 
![12312](https://user-images.githubusercontent.com/65351416/179292788-fef6945d-d26a-4b66-8939-47cac0f05c84.PNG)



