### PR TITLE
Seperate Email Sender into components

### DIFF
--- a/components/csvTable/CSVTable.tsx
+++ b/components/csvTable/CSVTable.tsx
@@ -9,10 +9,11 @@ import {
   TableRow
 } from '@mui/material'
 import { nanoid } from 'nanoid'
+import { CsvRow } from '../../lib/types'
 
 type CSVTableProps = {
   headers: String[];
-  rows: any;
+  rows: CsvRow[];
 };
 
 export default function CSVTable ({ headers, rows }: CSVTableProps) {

--- a/components/displayMessages/displayMessages.styles.tsx
+++ b/components/displayMessages/displayMessages.styles.tsx
@@ -1,0 +1,8 @@
+import { styled } from '@mui/material/styles'
+
+const StyledFinalMessagesContainer = styled('div')({
+  marginTop: 50,
+  marginBottom: 50
+})
+
+export { StyledFinalMessagesContainer }

--- a/components/displayMessages/displayMessages.tsx
+++ b/components/displayMessages/displayMessages.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { StyledFinalMessagesContainer } from '../../pageStyles/emailSender.styles'
+
+type DisplayMessagesProps = {
+    displayMessages: any,
+}
+
+export default function DisplayMessages ({ displayMessages } :DisplayMessagesProps) {
+  return (
+    <StyledFinalMessagesContainer>
+        {displayMessages()}
+    </StyledFinalMessagesContainer>
+  )
+}

--- a/components/displayMessages/displayMessages.tsx
+++ b/components/displayMessages/displayMessages.tsx
@@ -1,16 +1,37 @@
 import React from 'react'
+import { Message } from '../../lib/types'
+import { StyledDivider, StyledErrorMessage } from '../../pageStyles/emailSender.styles'
 import { StyledFinalMessagesContainer } from './displayMessages.styles'
+import FinalMessage from '../../components/finalMessage/finalMessage'
+import { nanoid } from 'nanoid'
 
 type DisplayMessagesProps = {
-  displayMessages: any;
+  finalMessages: Message[],
+  editFinalMessages: any,
+  getErrorMessage: any
 };
 
 export default function DisplayMessages ({
-  displayMessages
+  finalMessages, editFinalMessages, getErrorMessage
 }: DisplayMessagesProps) {
   return (
     <StyledFinalMessagesContainer>
-      {displayMessages()}
-    </StyledFinalMessagesContainer>
+{finalMessages.map((msg) => (
+          <div key={nanoid()}>
+            <StyledDivider />
+            {getErrorMessage(msg.id) && (
+              <StyledErrorMessage>
+                Error: {getErrorMessage(msg.id)}
+              </StyledErrorMessage>
+            )}
+            <FinalMessage
+              id={msg.id}
+              to={msg.to}
+              subject={msg.subject}
+              parentCallback={editFinalMessages}
+              content={msg.content}
+            />
+          </div>
+))}    </StyledFinalMessagesContainer>
   )
 }

--- a/components/displayMessages/displayMessages.tsx
+++ b/components/displayMessages/displayMessages.tsx
@@ -2,13 +2,15 @@ import React from 'react'
 import { StyledFinalMessagesContainer } from '../../pageStyles/emailSender.styles'
 
 type DisplayMessagesProps = {
-    displayMessages: any,
-}
+  displayMessages: any;
+};
 
-export default function DisplayMessages ({ displayMessages } :DisplayMessagesProps) {
+export default function DisplayMessages ({
+  displayMessages
+}: DisplayMessagesProps) {
   return (
     <StyledFinalMessagesContainer>
-        {displayMessages()}
+      {displayMessages()}
     </StyledFinalMessagesContainer>
   )
 }

--- a/components/displayMessages/displayMessages.tsx
+++ b/components/displayMessages/displayMessages.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyledFinalMessagesContainer } from '../../pageStyles/emailSender.styles'
+import { StyledFinalMessagesContainer } from './displayMessages.styles'
 
 type DisplayMessagesProps = {
   displayMessages: any;

--- a/components/emailContentSection/emailContentSection.tsx
+++ b/components/emailContentSection/emailContentSection.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
+import { SectionContainer, StyledTextArea } from '../../styles/common'
+
+type EmailContentProps = {
+    setMessage: any,
+
+}
+
+export default function EmailContent ({ setMessage } :EmailContentProps) {
+  return (
+    <SectionContainer>
+              <StyledSubHeader variant="h5">
+                2) Enter email content
+              </StyledSubHeader>
+              <StyledTextArea
+                aria-label="message-text-area"
+                placeholder="Paste in message"
+                onChange={(e) => setMessage(e.target.value)}
+                minRows={20}
+              />
+            </SectionContainer>
+  )
+}

--- a/components/emailContentSection/emailContentSection.tsx
+++ b/components/emailContentSection/emailContentSection.tsx
@@ -3,22 +3,19 @@ import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
 import { SectionContainer, StyledTextArea } from '../../styles/common'
 
 type EmailContentProps = {
-    setMessage: any,
+  setMessage: any;
+};
 
-}
-
-export default function EmailContent ({ setMessage } :EmailContentProps) {
+export default function EmailContent ({ setMessage }: EmailContentProps) {
   return (
     <SectionContainer>
-              <StyledSubHeader variant="h5">
-                2) Enter email content
-              </StyledSubHeader>
-              <StyledTextArea
-                aria-label="message-text-area"
-                placeholder="Paste in message"
-                onChange={(e) => setMessage(e.target.value)}
-                minRows={20}
-              />
-            </SectionContainer>
+      <StyledSubHeader variant="h5">2) Enter email content</StyledSubHeader>
+      <StyledTextArea
+        aria-label="message-text-area"
+        placeholder="Paste in message"
+        onChange={(e) => setMessage(e.target.value)}
+        minRows={20}
+      />
+    </SectionContainer>
   )
 }

--- a/components/finalMessage/finalMessage.tsx
+++ b/components/finalMessage/finalMessage.tsx
@@ -1,17 +1,26 @@
 import React, { useState } from 'react'
 import { Typography } from '@mui/material'
-import { StyledEditButton, StyledFinalMessageContent, StyledTextArea } from '../../styles/common'
+import {
+  StyledEditButton,
+  StyledFinalMessageContent,
+  StyledTextArea
+} from '../../styles/common'
 
 type FinalMessageProps = {
-    id: string,
-    to: string,
-    subject: string,
-    content: string,
-    parentCallback: Function,
+  id: string;
+  to: string;
+  subject: string;
+  content: string;
+  parentCallback: Function;
 };
 
-export default function FinalMessage
-({ id, to, subject, content, parentCallback }: FinalMessageProps) {
+export default function FinalMessage ({
+  id,
+  to,
+  subject,
+  content,
+  parentCallback
+}: FinalMessageProps) {
   const toMessage = to
   const subjectMessage = subject
   const idMail = id
@@ -34,38 +43,37 @@ export default function FinalMessage
 
   return (
     <>
-            <StyledEditButton
-                variant="contained"
-                size="small"
-                onClick={isEditing ? handleSubmitButton : handleEditButton}
-            >
-                {isEditing ? 'Save' : 'Edit'}
-            </StyledEditButton>
-            <Typography variant="body1">To: {toMessage}</Typography>
-            <Typography variant="body1">Subject: {subjectMessage}</Typography>
-            <br />
-            <Typography variant="body1">Content:</Typography>
-            <br />
-            <Typography variant="body1">
-
-                {isEditing
-                  ? <div>
-                        <StyledTextArea
-                            value={messageContent}
-                            id="outlined-basic"
-                            onChange={handleEditMessage}
-                        />
-                    </div>
-
-                  : <div>
-                        <StyledFinalMessageContent>
-
-                            {messageContent}
-                        </StyledFinalMessageContent>
-                    </div>
-
-                }
-            </Typography>
-            </>
+      <StyledEditButton
+        variant="contained"
+        size="small"
+        onClick={isEditing ? handleSubmitButton : handleEditButton}
+      >
+        {isEditing ? 'Save' : 'Edit'}
+      </StyledEditButton>
+      <Typography variant="body1">To: {toMessage}</Typography>
+      <Typography variant="body1">Subject: {subjectMessage}</Typography>
+      <br />
+      <Typography variant="body1">Content:</Typography>
+      <br />
+      <Typography variant="body1">
+        {isEditing
+          ? (
+          <div>
+            <StyledTextArea
+              value={messageContent}
+              id="outlined-basic"
+              onChange={handleEditMessage}
+            />
+          </div>
+            )
+          : (
+          <div>
+            <StyledFinalMessageContent>
+              {messageContent}
+            </StyledFinalMessageContent>
+          </div>
+            )}
+      </Typography>
+    </>
   )
 }

--- a/components/importCSVSection/importCSVSection.tsx
+++ b/components/importCSVSection/importCSVSection.tsx
@@ -2,10 +2,13 @@ import { Button } from '@mui/material'
 import React from 'react'
 import {
   SectionContainer,
-  StyledCsvButton,
-  StyledCsvButtonsContainer,
   StyledSubHeader
 } from '../../pageStyles/emailSender.styles'
+
+import {
+  StyledCsvButton,
+  StyledCsvButtonsContainer
+} from './importCsvSection.styles'
 
 type ImportCSVSectionProps = {
   file: boolean;

--- a/components/importCSVSection/importCSVSection.tsx
+++ b/components/importCSVSection/importCSVSection.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@mui/material'
+import React from 'react'
+import {
+  StyledCsvButton,
+  StyledCsvButtonsContainer,
+  StyledSubHeader
+} from '../../pageStyles/emailSender.styles'
+
+type ImportCSVSectionProps = {
+  file: boolean;
+  handleImportCsv: any;
+  handleUploadCsv: any;
+};
+
+export default function ImportCSVSection ({
+  file,
+  handleImportCsv,
+  handleUploadCsv
+}: ImportCSVSectionProps) {
+  return (
+    <>
+      <StyledSubHeader variant="h5">3) Upload and import csv</StyledSubHeader>
+      <StyledCsvButtonsContainer>
+        <input
+          style={{ display: 'none' }}
+          id="contained-button-file"
+          accept={'.csv'}
+          type="file"
+          onChange={handleUploadCsv}
+        />
+        <label htmlFor="contained-button-file">
+          <Button variant="contained" component="span">
+            Upload
+          </Button>
+        </label>
+        <StyledCsvButton
+          variant="contained"
+          width="medium"
+          disabled={file}
+          onClick={(e) => {
+            handleImportCsv(e)
+          }}
+        >
+          Import CSV!
+        </StyledCsvButton>
+      </StyledCsvButtonsContainer>
+    </>
+  )
+}

--- a/components/importCSVSection/importCSVSection.tsx
+++ b/components/importCSVSection/importCSVSection.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mui/material'
 import React from 'react'
 import {
+  SectionContainer,
   StyledCsvButton,
   StyledCsvButtonsContainer,
   StyledSubHeader
@@ -18,7 +19,7 @@ export default function ImportCSVSection ({
   handleUploadCsv
 }: ImportCSVSectionProps) {
   return (
-    <>
+    <SectionContainer>
       <StyledSubHeader variant="h5">3) Upload and import csv</StyledSubHeader>
       <StyledCsvButtonsContainer>
         <input
@@ -44,6 +45,6 @@ export default function ImportCSVSection ({
           Import CSV!
         </StyledCsvButton>
       </StyledCsvButtonsContainer>
-    </>
+    </SectionContainer>
   )
 }

--- a/components/importCSVSection/importCsvSection.styles.ts
+++ b/components/importCSVSection/importCsvSection.styles.ts
@@ -1,0 +1,15 @@
+import { styled } from '@mui/material/styles'
+import { StyledButton } from '../../styles/common'
+
+const StyledCsvButton = styled(StyledButton)({
+  marginLeft: 5,
+  marginRight: 5
+})
+
+const StyledCsvButtonsContainer = styled('div')({
+  display: 'flex'
+})
+
+export {
+  StyledCsvButton, StyledCsvButtonsContainer
+}

--- a/components/printMessages/printMessages.tsx
+++ b/components/printMessages/printMessages.tsx
@@ -3,12 +3,14 @@ import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
 import { SectionContainer, StyledButton } from '../../styles/common'
 
 type PrintMessagesProps = {
-    length: number,
-    createMessages: any,
+  length: number;
+  createMessages: any;
+};
 
-}
-
-export default function PrintMessages ({ length, createMessages } :PrintMessagesProps) {
+export default function PrintMessages ({
+  length,
+  createMessages
+}: PrintMessagesProps) {
   return (
     <SectionContainer>
       <StyledSubHeader variant="h5">4) Verify final messages</StyledSubHeader>

--- a/components/printMessages/printMessages.tsx
+++ b/components/printMessages/printMessages.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
+import { SectionContainer, StyledButton } from '../../styles/common'
+
+type PrintMessageProps = {
+    length: number,
+    createMessages: any,
+
+}
+
+export default function PrintMessage ({ length, createMessages } :PrintMessageProps) {
+  return (
+    <SectionContainer>
+      <StyledSubHeader variant="h5">4) Verify final messages</StyledSubHeader>
+      <StyledButton
+        color="info"
+        variant="contained"
+        onClick={createMessages}
+        disabled={length === 0}
+        width="medium"
+      >
+        Print final messages
+      </StyledButton>
+    </SectionContainer>
+  )
+}

--- a/components/printMessages/printMessages.tsx
+++ b/components/printMessages/printMessages.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
 import { SectionContainer, StyledButton } from '../../styles/common'
 
-type PrintMessageProps = {
+type PrintMessagesProps = {
     length: number,
     createMessages: any,
 
 }
 
-export default function PrintMessage ({ length, createMessages } :PrintMessageProps) {
+export default function PrintMessages ({ length, createMessages } :PrintMessagesProps) {
   return (
     <SectionContainer>
       <StyledSubHeader variant="h5">4) Verify final messages</StyledSubHeader>

--- a/components/sendEmails/sendEmails.tsx
+++ b/components/sendEmails/sendEmails.tsx
@@ -22,18 +22,18 @@ import {
 import { SectionContainer, StyledButton } from '../../styles/common'
 
 type SendEmailsProps = {
-    setCheckedDeliveryBox : any,
-    checkedDeliveryBox : boolean,
-    dateTime : Date | null,
-    handleClickOpen : any,
-    setDeliveryDateTime : any,
-    finalMessagesLength : boolean,
-    errorMessagesLength : boolean,
-    handleClose : any,
-    sendEmails : any,
-    resultMessage : ResultMessage,
-    open : boolean
-}
+  setCheckedDeliveryBox: any;
+  checkedDeliveryBox: boolean;
+  dateTime: Date | null;
+  handleClickOpen: any;
+  setDeliveryDateTime: any;
+  finalMessagesLength: boolean;
+  errorMessagesLength: boolean;
+  handleClose: any;
+  sendEmails: any;
+  resultMessage: ResultMessage;
+  open: boolean;
+};
 
 export default function SendEmails ({
   setCheckedDeliveryBox,
@@ -47,79 +47,77 @@ export default function SendEmails ({
   sendEmails,
   resultMessage,
   open
-} :SendEmailsProps) {
+}: SendEmailsProps) {
   return (
     <SectionContainer>
-    <StyledSubHeader variant="h5">5) Send emails</StyledSubHeader>
-    <FormLabel id="choose-email-subject">
-      Use customized or standard email subjects?
-    </FormLabel>
-    <FormGroup>
-      <FormControlLabel
-        control={
-          <Checkbox
-            onChange={(e) => setCheckedDeliveryBox(e.target.checked)}
-          />
-        }
-        label="Select custom delivery time"
-      />
-    </FormGroup>
-    {checkedDeliveryBox &&
-    <StyledDateTimeDiv>
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Stack spacing={3}>
-        <DateTimePicker
-          label="Select date and time"
-          value={dateTime}
-          onChange={(dateTime: Date | null) => {
-            setDeliveryDateTime(dateTime)
-          }}
-          renderInput={(params: any) => <TextField {...params} />}
+      <StyledSubHeader variant="h5">5) Send emails</StyledSubHeader>
+      <FormLabel id="choose-email-subject">
+        Use customized or standard email subjects?
+      </FormLabel>
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Checkbox
+              onChange={(e) => setCheckedDeliveryBox(e.target.checked)}
+            />
+          }
+          label="Select custom delivery time"
         />
-      </Stack>
-    </LocalizationProvider>
-  </StyledDateTimeDiv>}
-    <StyledButton
-      color="info"
-      variant="contained"
-      onClick={() => {
-        handleClickOpen()
-      }}
-      width="medium"
-      disabled={finalMessagesLength || errorMessagesLength}
-    >
-      Send!
-    </StyledButton>
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-    >
-      <DialogTitle id="alert-dialog-title">
-        Are you sure you want to send all emails?
-      </DialogTitle>
-      <DialogActions>
-        <Button variant="contained" onClick={handleClose}>
-          No
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={() => {
-            handleClose()
-            sendEmails()
-          }}
-          autoFocus
-        >
-          Yes
-        </Button>
-      </DialogActions>
-    </Dialog>
-    <StyledResultMessage
-      variant="h5"
-      isError={resultMessage.isError}
-    >
-      {resultMessage.message}
-    </StyledResultMessage>
-  </SectionContainer>
+      </FormGroup>
+      {checkedDeliveryBox && (
+        <StyledDateTimeDiv>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Stack spacing={3}>
+              <DateTimePicker
+                label="Select date and time"
+                value={dateTime}
+                onChange={(dateTime: Date | null) => {
+                  setDeliveryDateTime(dateTime)
+                }}
+                renderInput={(params: any) => <TextField {...params} />}
+              />
+            </Stack>
+          </LocalizationProvider>
+        </StyledDateTimeDiv>
+      )}
+      <StyledButton
+        color="info"
+        variant="contained"
+        onClick={() => {
+          handleClickOpen()
+        }}
+        width="medium"
+        disabled={finalMessagesLength || errorMessagesLength}
+      >
+        Send!
+      </StyledButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+      >
+        <DialogTitle id="alert-dialog-title">
+          Are you sure you want to send all emails?
+        </DialogTitle>
+        <DialogActions>
+          <Button variant="contained" onClick={handleClose}>
+            No
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              handleClose()
+              sendEmails()
+            }}
+            autoFocus
+          >
+            Yes
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <StyledResultMessage variant="h5" isError={resultMessage.isError}>
+        {resultMessage.message}
+      </StyledResultMessage>
+    </SectionContainer>
   )
 }

--- a/components/sendEmails/sendEmails.tsx
+++ b/components/sendEmails/sendEmails.tsx
@@ -1,0 +1,125 @@
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
+  Stack,
+  TextField
+} from '@mui/material'
+import { LocalizationProvider, DateTimePicker } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import React from 'react'
+import { ResultMessage } from '../../lib/types'
+import {
+  StyledDateTimeDiv,
+  StyledResultMessage,
+  StyledSubHeader
+} from '../../pageStyles/emailSender.styles'
+import { SectionContainer, StyledButton } from '../../styles/common'
+
+type SendEmailsProps = {
+    setCheckedDeliveryBox : any,
+    checkedDeliveryBox : boolean,
+    dateTime : Date | null,
+    handleClickOpen : any,
+    setDeliveryDateTime : any,
+    finalMessagesLength : boolean,
+    errorMessagesLength : boolean,
+    handleClose : any,
+    sendEmails : any,
+    resultMessage : ResultMessage,
+    open : boolean
+}
+
+export default function SendEmails ({
+  setCheckedDeliveryBox,
+  checkedDeliveryBox,
+  dateTime,
+  handleClickOpen,
+  setDeliveryDateTime,
+  finalMessagesLength,
+  errorMessagesLength,
+  handleClose,
+  sendEmails,
+  resultMessage,
+  open
+} :SendEmailsProps) {
+  return (
+    <SectionContainer>
+    <StyledSubHeader variant="h5">5) Send emails</StyledSubHeader>
+    <FormLabel id="choose-email-subject">
+      Use customized or standard email subjects?
+    </FormLabel>
+    <FormGroup>
+      <FormControlLabel
+        control={
+          <Checkbox
+            onChange={(e) => setCheckedDeliveryBox(e.target.checked)}
+          />
+        }
+        label="Select custom delivery time"
+      />
+    </FormGroup>
+    {checkedDeliveryBox &&
+    <StyledDateTimeDiv>
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Stack spacing={3}>
+        <DateTimePicker
+          label="Select date and time"
+          value={dateTime}
+          onChange={(dateTime: Date | null) => {
+            setDeliveryDateTime(dateTime)
+          }}
+          renderInput={(params: any) => <TextField {...params} />}
+        />
+      </Stack>
+    </LocalizationProvider>
+  </StyledDateTimeDiv>}
+    <StyledButton
+      color="info"
+      variant="contained"
+      onClick={() => {
+        handleClickOpen()
+      }}
+      width="medium"
+      disabled={finalMessagesLength || errorMessagesLength}
+    >
+      Send!
+    </StyledButton>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+    >
+      <DialogTitle id="alert-dialog-title">
+        Are you sure you want to send all emails?
+      </DialogTitle>
+      <DialogActions>
+        <Button variant="contained" onClick={handleClose}>
+          No
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            handleClose()
+            sendEmails()
+          }}
+          autoFocus
+        >
+          Yes
+        </Button>
+      </DialogActions>
+    </Dialog>
+    <StyledResultMessage
+      variant="h5"
+      isError={resultMessage.isError}
+    >
+      {resultMessage.message}
+    </StyledResultMessage>
+  </SectionContainer>
+  )
+}

--- a/components/subjectSection/subjectSection.tsx
+++ b/components/subjectSection/subjectSection.tsx
@@ -1,0 +1,44 @@
+
+import React from 'react'
+import { FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material'
+import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
+import { SectionContainer } from '../../styles/common'
+
+type SubjectSectionProps = {
+    handleEmailStandard : any,
+    printStandardEmailSubject : any,
+}
+
+export default function SubjectSection ({ handleEmailStandard, printStandardEmailSubject }
+    : SubjectSectionProps) {
+  return (
+    <>
+      <SectionContainer>
+        <StyledSubHeader variant="h5">1) Email subject</StyledSubHeader>
+        <FormLabel id="choose-email-subject">
+          Use customized or standard email subjects?
+        </FormLabel>
+        <RadioGroup
+          aria-labelledby="choose-email-subject"
+          name="email-subject"
+          onChange={handleEmailStandard}
+        >
+          <FormControlLabel
+            value="customized"
+            control={<Radio />}
+            label="Customized (add subjects from CSV)"
+          />
+          <FormControlLabel
+            value="standard"
+            control={<Radio />}
+            label="Standard (enter one subject for all emails)"
+          />
+        </RadioGroup>
+        <br />
+      </SectionContainer>
+      <SectionContainer>
+        <div>{printStandardEmailSubject()}</div>
+      </SectionContainer>
+    </>
+  )
+}

--- a/components/subjectSection/subjectSection.tsx
+++ b/components/subjectSection/subjectSection.tsx
@@ -1,16 +1,17 @@
-
 import React from 'react'
 import { FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material'
 import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
 import { SectionContainer } from '../../styles/common'
 
 type SubjectSectionProps = {
-    handleEmailStandard : any,
-    printStandardEmailSubject : any,
-}
+  handleEmailStandard: any;
+  printStandardEmailSubject: any;
+};
 
-export default function SubjectSection ({ handleEmailStandard, printStandardEmailSubject }
-    : SubjectSectionProps) {
+export default function SubjectSection ({
+  handleEmailStandard,
+  printStandardEmailSubject
+}: SubjectSectionProps) {
   return (
     <>
       <SectionContainer>

--- a/components/subjectSection/subjectSection.tsx
+++ b/components/subjectSection/subjectSection.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 import { FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material'
-import { StyledSubHeader } from '../../pageStyles/emailSender.styles'
+import { StyledSubHeader, StyledTextField } from '../../pageStyles/emailSender.styles'
 import { SectionContainer } from '../../styles/common'
 
 type SubjectSectionProps = {
-  handleEmailStandard: any;
-  printStandardEmailSubject: any;
+  handleEmailStandard: any,
+  subjectCustomization: boolean,
+  handleEmailSubject: any
 };
 
 export default function SubjectSection ({
   handleEmailStandard,
-  printStandardEmailSubject
+  subjectCustomization,
+  handleEmailSubject
 }: SubjectSectionProps) {
   return (
     <>
@@ -38,8 +40,20 @@ export default function SubjectSection ({
         <br />
       </SectionContainer>
       <SectionContainer>
-        <div>{printStandardEmailSubject()}</div>
-      </SectionContainer>
+        {!subjectCustomization &&
+        <div>
+          <StyledSubHeader variant="h5">
+            1b) Enter standard email subject
+          </StyledSubHeader>
+          <StyledTextField
+            id="outlined-basic"
+            label="Email subject"
+            variant="outlined"
+            onChange={handleEmailSubject}
+          />
+        </div>
+    }
+     </SectionContainer>
     </>
   )
 }

--- a/pageStyles/emailSender.styles.ts
+++ b/pageStyles/emailSender.styles.ts
@@ -1,6 +1,5 @@
 import { Divider, Table, TableRow, TextField, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { StyledButton } from '../styles/common'
 import { theme } from '../styles/theme'
 
 const SectionContainer = styled('div')({
@@ -8,21 +7,7 @@ const SectionContainer = styled('div')({
   marginBottom: 30
 })
 
-const StyledCsvButton = styled(StyledButton)({
-  marginLeft: 5,
-  marginRight: 5
-})
-
-const StyledCsvButtonsContainer = styled('div')({
-  display: 'flex'
-})
-
 const StyledDivider = styled(Divider)({
-  marginTop: 50,
-  marginBottom: 50
-})
-
-const StyledFinalMessagesContainer = styled('div')({
   marginTop: 50,
   marginBottom: 50
 })
@@ -70,8 +55,7 @@ const StyledFinalMessageContent = styled('div')({
 })
 
 export {
-  SectionContainer, StyledTextField, StyledCsvButton, StyledCsvButtonsContainer,
-  StyledSubHeader, StyledFinalMessagesContainer, StyledTableContainer, StyledDivider,
+  SectionContainer, StyledTextField, StyledSubHeader, StyledTableContainer, StyledDivider,
   StyledTable, StyledTableRow, StyledFinalMessageContent, StyledErrorMessage, StyledResultMessage,
   StyledDateTimeDiv
 }

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -40,8 +40,6 @@ import {
   ResultMessage
 } from '../lib/types'
 import {
-  StyledCsvButton,
-  StyledCsvButtonsContainer,
   StyledDivider,
   StyledErrorMessage,
   StyledFinalMessagesContainer,
@@ -63,6 +61,12 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
 import Stack from '@mui/material/Stack'
+import PrintMessage from '../components/printMessages/printMessages'
+import ImportCSVSection from '../components/importCSVSection/importCSVSection'
+import SubjectSection from '../components/subjectSection/subjectSection'
+import EmailContent from '../components/emailContentSection/emailContentSection'
+import SendEmails from '../components/sendEmails/sendEmails'
+import CSVTable from '../components/csvTable/CSVTable'
 
 const EmailSender: NextPage = () => {
   const { data: session } = useSession({ required: true })
@@ -360,73 +364,19 @@ const EmailSender: NextPage = () => {
             </Link>
           </Typography>
           <FormControl fullWidth>
+            <SubjectSection
+            handleEmailStandard={handleEmailStandard}
+            printStandardEmailSubject={printStandardEmailSubject}
+            />
+           <EmailContent
+           setMessage={setMessage}
+           />
             <SectionContainer>
-              <StyledSubHeader variant="h5">
-                1) Email subject
-              </StyledSubHeader>
-              <FormLabel id="choose-email-subject">
-                Use customized or standard email subjects?
-              </FormLabel>
-              <RadioGroup
-                aria-labelledby="choose-email-subject"
-                name="email-subject"
-                onChange={handleEmailStandard}
-              >
-                <FormControlLabel
-                  value="customized"
-                  control={<Radio />}
-                  label="Customized (add subjects from CSV)"
-                />
-                <FormControlLabel
-                  value="standard"
-                  control={<Radio />}
-                  label="Standard (enter one subject for all emails)"
-                />
-              </RadioGroup>
-              <br />
-            </SectionContainer>
-            <SectionContainer>
-              <div>{printStandardEmailSubject()}</div>
-            </SectionContainer>
-            <SectionContainer>
-              <StyledSubHeader variant="h5">
-                2) Enter email content
-              </StyledSubHeader>
-              <StyledTextArea
-                aria-label="message-text-area"
-                placeholder="Paste in message"
-                onChange={(e) => setMessage(e.target.value)}
-                minRows={20}
+              <ImportCSVSection
+              file={file === undefined}
+              handleImportCsv={handleImportCsv}
+              handleUploadCsv={handleUploadCsv}
               />
-            </SectionContainer>
-            <SectionContainer>
-              <StyledSubHeader variant="h5">
-                3) Upload and import csv
-              </StyledSubHeader>
-              <StyledCsvButtonsContainer>
-                <input
-                  style={{ display: 'none' }}
-                  id="contained-button-file"
-                  accept={'.csv'}
-                  type="file"
-                  onChange={handleUploadCsv}
-                />
-                <label htmlFor="contained-button-file">
-                  <Button variant="contained" component="span">
-                    Upload
-                  </Button>
-                </label>
-                <StyledCsvButton
-                  variant="contained"
-                  width="medium"
-                  disabled={file === undefined}
-                  onClick={(e) => {
-                    handleImportCsv(e)
-                  }}
-                >
-                  Import CSV!
-                </StyledCsvButton>
-              </StyledCsvButtonsContainer>
               {errorMessages.map((errorMessage) => (
                 <StyledErrorMessage key={errorMessage.id}>
                   <br />
@@ -435,120 +385,29 @@ const EmailSender: NextPage = () => {
               ))}
             </SectionContainer>
           </FormControl>
-          <StyledTableContainer>
-            <TableContainer component={Paper}>
-              <StyledTable aria-label="uploaded csv table">
-                <TableHead>
-                  {headerKeys.map((key) => (
-                    <TableCell key={nanoid()}>
-                      <StyledBoldTypograhy variant="body1">
-                        {key}
-                      </StyledBoldTypograhy>
-                    </TableCell>
-                  ))}
-                </TableHead>
-                <TableBody>
-                  {csvRowsArray.map((item) => (
-                    <StyledTableRow key={nanoid()}>
-                      {Object.values(item).map((val) => (
-                        <TableCell key={nanoid()} align="left">
-                          {val}
-                        </TableCell>
-                      ))}
-                    </StyledTableRow>
-                  ))}
-                </TableBody>
-              </StyledTable>
-            </TableContainer>
-          </StyledTableContainer>
-          <SectionContainer>
-            <StyledSubHeader variant="h5">
-              4) Verify final messages
-            </StyledSubHeader>
-            <StyledButton
-              color="info"
-              variant="contained"
-              onClick={createMessages}
-              disabled={csvRowsArray.length === 0}
-              width="medium"
-            >
-              Print final messages
-            </StyledButton>
-          </SectionContainer>
+          <CSVTable
+          headers={headerKeys}
+          rows={csvRowsArray}
+          />
+          <PrintMessage
+          length={csvRowsArray.length}
+          createMessages={createMessages}
+          />
           <br />
           <br />
-          <SectionContainer>
-            <StyledSubHeader variant="h5">5) Send emails</StyledSubHeader>
-            <FormLabel id="choose-email-subject">
-              Use customized or standard email subjects?
-            </FormLabel>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    onChange={(e) => setCheckedDeliveryBox(e.target.checked)}
-                  />
-                }
-                label="Select custom delivery time"
-              />
-            </FormGroup>
-            {checkedDeliveryBox &&
-            <StyledDateTimeDiv>
-            <LocalizationProvider dateAdapter={AdapterDateFns}>
-              <Stack spacing={3}>
-                <DateTimePicker
-                  label="Select date and time"
-                  value={dateTime}
-                  onChange={(dateTime: Date | null) => {
-                    setDeliveryDateTime(dateTime)
-                  }}
-                  renderInput={(params: any) => <TextField {...params} />}
-                />
-              </Stack>
-            </LocalizationProvider>
-          </StyledDateTimeDiv>}
-            <StyledButton
-              color="info"
-              variant="contained"
-              onClick={() => {
-                handleClickOpen()
-              }}
-              width="medium"
-              disabled={finalMessages.length === 0 || errorMessages.length > 0}
-            >
-              Send!
-            </StyledButton>
-            <Dialog
-              open={open}
-              onClose={handleClose}
-              aria-labelledby="alert-dialog-title"
-            >
-              <DialogTitle id="alert-dialog-title">
-                Are you sure you want to send all emails?
-              </DialogTitle>
-              <DialogActions>
-                <Button variant="contained" onClick={handleClose}>
-                  No
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => {
-                    handleClose()
-                    sendEmails()
-                  }}
-                  autoFocus
-                >
-                  Yes
-                </Button>
-              </DialogActions>
-            </Dialog>
-            <StyledResultMessage
-              variant="h5"
-              isError={resultMessage.isError}
-            >
-              {resultMessage.message}
-            </StyledResultMessage>
-          </SectionContainer>
+          <SendEmails
+          setCheckedDeliveryBox={setCheckedDeliveryBox}
+          checkedDeliveryBox={checkedDeliveryBox}
+          dateTime={dateTime}
+          handleClickOpen={handleClickOpen}
+          setDeliveryDateTime={setDeliveryDateTime}
+          finalMessagesLength={finalMessages.length === 0}
+          errorMessagesLength={errorMessages.length > 0}
+          handleClose={handleClose}
+          sendEmails={sendEmails}
+          resultMessage={resultMessage}
+          open={open}
+          />
           <StyledFinalMessagesContainer>
             {displayMessages()}
           </StyledFinalMessagesContainer>

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -24,7 +24,6 @@ import {
 import {
   StyledDivider,
   StyledErrorMessage,
-  StyledFinalMessagesContainer,
   StyledSubHeader,
   StyledTextField
 } from '../pageStyles/emailSender.styles'
@@ -39,6 +38,7 @@ import SubjectSection from '../components/subjectSection/subjectSection'
 import EmailContent from '../components/emailContentSection/emailContentSection'
 import SendEmails from '../components/sendEmails/sendEmails'
 import CSVTable from '../components/csvTable/CSVTable'
+import DisplayMessages from '../components/displayMessages/displayMessages'
 
 const EmailSender: NextPage = () => {
   const { data: session } = useSession({ required: true })
@@ -380,9 +380,9 @@ const EmailSender: NextPage = () => {
           resultMessage={resultMessage}
           open={open}
           />
-          <StyledFinalMessagesContainer>
-            {displayMessages()}
-          </StyledFinalMessagesContainer>
+          <DisplayMessages
+          displayMessages={displayMessages}
+          />
         </StyledPageContainer>
       </ThemeProvider>
     </Layout>

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -19,11 +19,9 @@ import {
   ResultMessage
 } from '../lib/types'
 import {
-  StyledDivider,
   StyledErrorMessage
 } from '../pageStyles/emailSender.styles'
 import Layout from '../components/layout/Layout'
-import FinalMessage from '../components/finalMessage/finalMessage'
 import { GetServerSideProps } from 'next'
 import { getServerSideSessionOrRedirect } from '../server/getServerSideSessionOrRedirect'
 import { validEmail } from '../lib/validateEmail'
@@ -255,30 +253,6 @@ const EmailSender: NextPage = () => {
       ?.message
   }
 
-  const displayMessages = () => {
-    return (
-      <>
-        {finalMessages.map((msg) => (
-          <div key={nanoid()}>
-            <StyledDivider />
-            {getErrorMessage(msg.id) && (
-              <StyledErrorMessage>
-                Error: {getErrorMessage(msg.id)}
-              </StyledErrorMessage>
-            )}
-            <FinalMessage
-              id={msg.id}
-              to={msg.to}
-              subject={msg.subject}
-              parentCallback={editFinalMessages}
-              content={msg.content}
-            />
-          </div>
-        ))}
-      </>
-    )
-  }
-
   const sendEmails = () => {
     // format: 'FName LName <email@hackbeanpot.com>'
     const from = '' + session?.user?.name + ' <' + session?.user?.email + '>'
@@ -372,7 +346,11 @@ const EmailSender: NextPage = () => {
             resultMessage={resultMessage}
             open={open}
           />
-          <DisplayMessages displayMessages={displayMessages} />
+          <DisplayMessages
+          finalMessages={finalMessages}
+          editFinalMessages={editFinalMessages}
+          getErrorMessage={getErrorMessage}
+          />
         </StyledPageContainer>
       </ThemeProvider>
     </Layout>

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -10,10 +10,7 @@ import type { NextPage } from 'next'
 import { useSession } from 'next-auth/react'
 import { nanoid } from 'nanoid'
 import { useTheme } from '@mui/material/styles'
-import {
-  StyledPageContainer,
-  SectionContainer
-} from '../styles/common'
+import { StyledPageContainer, SectionContainer } from '../styles/common'
 import {
   CsvRow,
   ReplaceObj,
@@ -51,7 +48,10 @@ const EmailSender: NextPage = () => {
   const [message, setMessage] = useState('')
   const [finalMessages, setFinalMessages] = useState<Message[]>([])
   const [errorMessages, setErrorMessages] = useState<ErrorMessage[]>([])
-  const [resultMessage, setResultMessage] = useState<ResultMessage>({ isError: false, message: '' })
+  const [resultMessage, setResultMessage] = useState<ResultMessage>({
+    isError: false,
+    message: ''
+  })
   const theme = useTheme()
   const [dateTime, setDeliveryDateTime] = useState<Date | null>(null)
 
@@ -61,10 +61,15 @@ const EmailSender: NextPage = () => {
       : setSubjectCustomization(true)
   }
 
-  const editFinalMessages = (id: string, to: string, subject: string, messageContent: string) => {
+  const editFinalMessages = (
+    id: string,
+    to: string,
+    subject: string,
+    messageContent: string
+  ) => {
     const finalMessageArr = []
     const content = messageContent
-    const finalMessageIndex = finalMessages.findIndex(finalMessage => {
+    const finalMessageIndex = finalMessages.findIndex((finalMessage) => {
       return finalMessage.id === id
     })
     for (let i = 0; i < finalMessages.length; i++) {
@@ -107,10 +112,12 @@ const EmailSender: NextPage = () => {
   const handleUploadCsv = (e: any) => {
     const filename = e.target.files[0].name
     if (filename.substring(filename.length - 3) !== 'csv') {
-      setErrorMessages([{
-        id: nanoid(),
-        message: 'Uploaded file must be a .csv file'
-      }])
+      setErrorMessages([
+        {
+          id: nanoid(),
+          message: 'Uploaded file must be a .csv file'
+        }
+      ])
     } else {
       setFile(e.target.files[0])
       setErrorMessages([])
@@ -122,14 +129,18 @@ const EmailSender: NextPage = () => {
   const csvFileToArray = (str: string) => {
     const csvHeaders = str.slice(0, str.indexOf('\n')).trim().split(',')
     if (!csvHeaders.includes('email')) {
-      setErrorMessages([{ id: nanoid(), message: 'CSV must contain an email column' }])
+      setErrorMessages([
+        { id: nanoid(), message: 'CSV must contain an email column' }
+      ])
       return
     }
     if (!csvHeaders.includes('subject') && subjectCustomization) {
-      setErrorMessages([{
-        id: nanoid(),
-        message: 'CSV must contain a subject column if subject is customized'
-      }])
+      setErrorMessages([
+        {
+          id: nanoid(),
+          message: 'CSV must contain a subject column if subject is customized'
+        }
+      ])
       return
     }
     let allRowValues = str.slice(str.indexOf('\n') + 1).split('\n')
@@ -146,9 +157,12 @@ const EmailSender: NextPage = () => {
         },
         {}
       )
-      if (currRowObject.email && Object.values(currRowObject)
-        .map((value) => typeof value === 'string' ? value.trim() : value)
-        .includes('')) {
+      if (
+        currRowObject.email &&
+        Object.values(currRowObject)
+          .map((value) => (typeof value === 'string' ? value.trim() : value))
+          .includes('')
+      ) {
         errorList.push({
           id: nanoid(),
           message: 'CSV cannot contain empty cells'
@@ -173,11 +187,16 @@ const EmailSender: NextPage = () => {
       allRowObjects.pop()
     }
 
-    if (new Set(allRowObjects.map((rowObj) => rowObj.email)).size !== allRowObjects.length) {
-      setErrorMessages([{
-        id: nanoid(),
-        message: 'No email address should appear more than once'
-      }])
+    if (
+      new Set(allRowObjects.map((rowObj) => rowObj.email)).size !==
+      allRowObjects.length
+    ) {
+      setErrorMessages([
+        {
+          id: nanoid(),
+          message: 'No email address should appear more than once'
+        }
+      ])
       return
     }
 
@@ -252,9 +271,8 @@ const EmailSender: NextPage = () => {
   }
 
   const getErrorMessage = (id: string) => {
-    return errorMessages.find(
-      (currentMessage) => currentMessage.id === id
-    )?.message
+    return errorMessages.find((currentMessage) => currentMessage.id === id)
+      ?.message
   }
 
   const displayMessages = () => {
@@ -287,9 +305,7 @@ const EmailSender: NextPage = () => {
     const dataToSend = {
       emailData: finalMessages,
       from,
-      date: checkedDeliveryBox
-        ? dateTime?.toUTCString()
-        : undefined
+      date: checkedDeliveryBox ? dateTime?.toUTCString() : undefined
     }
     fetch('/api/email/send', {
       method: 'POST',
@@ -337,18 +353,16 @@ const EmailSender: NextPage = () => {
           </Typography>
           <FormControl fullWidth>
             <SubjectSection
-            handleEmailStandard={handleEmailStandard}
-            printStandardEmailSubject={printStandardEmailSubject}
+              handleEmailStandard={handleEmailStandard}
+              printStandardEmailSubject={printStandardEmailSubject}
             />
-           <EmailContent
-           setMessage={setMessage}
-           />
-            <SectionContainer>
-              <ImportCSVSection
+            <EmailContent setMessage={setMessage} />
+            <ImportCSVSection
               file={file === undefined}
               handleImportCsv={handleImportCsv}
               handleUploadCsv={handleUploadCsv}
-              />
+            />
+            <SectionContainer>
               {errorMessages.map((errorMessage) => (
                 <StyledErrorMessage key={errorMessage.id}>
                   <br />
@@ -357,32 +371,27 @@ const EmailSender: NextPage = () => {
               ))}
             </SectionContainer>
           </FormControl>
-          <CSVTable
-          headers={headerKeys}
-          rows={csvRowsArray}
-          />
+          <CSVTable headers={headerKeys} rows={csvRowsArray} />
           <PrintMessage
-          length={csvRowsArray.length}
-          createMessages={createMessages}
+            length={csvRowsArray.length}
+            createMessages={createMessages}
           />
           <br />
           <br />
           <SendEmails
-          setCheckedDeliveryBox={setCheckedDeliveryBox}
-          checkedDeliveryBox={checkedDeliveryBox}
-          dateTime={dateTime}
-          handleClickOpen={handleClickOpen}
-          setDeliveryDateTime={setDeliveryDateTime}
-          finalMessagesLength={finalMessages.length === 0}
-          errorMessagesLength={errorMessages.length > 0}
-          handleClose={handleClose}
-          sendEmails={sendEmails}
-          resultMessage={resultMessage}
-          open={open}
+            setCheckedDeliveryBox={setCheckedDeliveryBox}
+            checkedDeliveryBox={checkedDeliveryBox}
+            dateTime={dateTime}
+            handleClickOpen={handleClickOpen}
+            setDeliveryDateTime={setDeliveryDateTime}
+            finalMessagesLength={finalMessages.length === 0}
+            errorMessagesLength={errorMessages.length > 0}
+            handleClose={handleClose}
+            sendEmails={sendEmails}
+            resultMessage={resultMessage}
+            open={open}
           />
-          <DisplayMessages
-          displayMessages={displayMessages}
-          />
+          <DisplayMessages displayMessages={displayMessages} />
         </StyledPageContainer>
       </ThemeProvider>
     </Layout>

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -20,9 +20,7 @@ import {
 } from '../lib/types'
 import {
   StyledDivider,
-  StyledErrorMessage,
-  StyledSubHeader,
-  StyledTextField
+  StyledErrorMessage
 } from '../pageStyles/emailSender.styles'
 import Layout from '../components/layout/Layout'
 import FinalMessage from '../components/finalMessage/finalMessage'
@@ -81,24 +79,6 @@ const EmailSender: NextPage = () => {
       }
     }
     setFinalMessages(finalMessageArr)
-  }
-
-  const printStandardEmailSubject = () => {
-    if (!subjectCustomization) {
-      return (
-        <div>
-          <StyledSubHeader variant="h5">
-            1b) Enter standard email subject
-          </StyledSubHeader>
-          <StyledTextField
-            id="outlined-basic"
-            label="Email subject"
-            variant="outlined"
-            onChange={handleEmailSubject}
-          />
-        </div>
-      )
-    }
   }
 
   const handleEmailSubject = (e: ChangeEvent<HTMLInputElement>) => {
@@ -354,7 +334,8 @@ const EmailSender: NextPage = () => {
           <FormControl fullWidth>
             <SubjectSection
               handleEmailStandard={handleEmailStandard}
-              printStandardEmailSubject={printStandardEmailSubject}
+              subjectCustomization={subjectCustomization}
+              handleEmailSubject={handleEmailSubject}
             />
             <EmailContent setMessage={setMessage} />
             <ImportCSVSection

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -1,36 +1,18 @@
 import React, { ChangeEvent, useState } from 'react'
 import {
   ThemeProvider,
-  Button,
   Divider,
   Link,
   FormControl,
-  FormControlLabel,
-  FormLabel,
-  Radio,
-  RadioGroup,
-  Paper,
-  TableBody,
-  TableContainer,
-  TableCell,
-  TableHead,
-  Typography,
-  Dialog,
-  DialogActions,
-  DialogTitle,
-  FormGroup,
-  Checkbox
+  Typography
 } from '@mui/material'
 import type { NextPage } from 'next'
 import { useSession } from 'next-auth/react'
 import { nanoid } from 'nanoid'
 import { useTheme } from '@mui/material/styles'
 import {
-  StyledButton,
   StyledPageContainer,
-  StyledBoldTypograhy,
-  SectionContainer,
-  StyledTextArea
+  SectionContainer
 } from '../styles/common'
 import {
   CsvRow,
@@ -43,24 +25,14 @@ import {
   StyledDivider,
   StyledErrorMessage,
   StyledFinalMessagesContainer,
-  StyledResultMessage,
   StyledSubHeader,
-  StyledTable,
-  StyledTableContainer,
-  StyledTableRow,
-  StyledTextField,
-  StyledDateTimeDiv
+  StyledTextField
 } from '../pageStyles/emailSender.styles'
 import Layout from '../components/layout/Layout'
 import FinalMessage from '../components/finalMessage/finalMessage'
 import { GetServerSideProps } from 'next'
 import { getServerSideSessionOrRedirect } from '../server/getServerSideSessionOrRedirect'
 import { validEmail } from '../lib/validateEmail'
-import TextField from '@mui/material/TextField'
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
-import Stack from '@mui/material/Stack'
 import PrintMessage from '../components/printMessages/printMessages'
 import ImportCSVSection from '../components/importCSVSection/importCSVSection'
 import SubjectSection from '../components/subjectSection/subjectSection'


### PR DESCRIPTION
closes #65 

### This PR includes the following changes
- Separated EmailSender into the following components
- SubjectSection
- EmailContentSection
- ImportCSVSection
- PrintMessages
- SendEmails
- CSVTable (by Lisa<3)

Verified that the site functions as it did before.

<img width="1800" alt="Screen Shot 2022-07-26 at 8 59 03 PM" src="https://user-images.githubusercontent.com/103906123/181137745-a6008e16-c166-44cb-8a87-c9b4064b663d.png">

