### PR TITLE
Create PR template in new general docs folder.

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,16 @@
+<Summary line - One sentence describing your intended set of changes>
+
+Fixes #<bug number>.
+
+Changelist:
+- Describe your key changes
+- Use concise bullet points so that reviewers can quickly identify what objectives this PR achieves
+
+Notes:
+- Optional section, feel free to delete if PR was very straightforward, but otherwise additional context is great
+- Design decisions: elaborate as necessary
+- Extensions: List any blockers or follow-ups that require attention
+
+Tested:
+- Explain testing strategies here (remember to do all relevant testing, eg. unit, e2e, manual)
+- Include screenshots and screencasts as relevant

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -13,4 +13,9 @@ Notes:
 
 Tested:
 - Explain testing strategies here (remember to do all relevant testing, eg. unit, e2e, manual)
+- Remember to make changes and re-test when you put out any PR revisions
+  
+Screenshots & Screencasts:
 - Include screenshots and screencasts as relevant
+- Be liberal and provide all the user / developer flow context that you can
+- Remember to make changes and re-render when you put out any PR revisions


### PR DESCRIPTION
Introduces a PR template to help us standardize commits quality.

Partially resolves #[67](https://github.com/HackBeanpot/internal-tools/issues/67).

Notes:
- Followed Github docs to create the PR template:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- Using the proposed PR structure for this! How meta

Tested:
N/A, will use it to create a new PR and manual test after it is first merged in.