### PR TITLE
Verify login status on help page.

### DIFF
--- a/pages/emailSenderHelp.tsx
+++ b/pages/emailSenderHelp.tsx
@@ -7,6 +7,8 @@ import { StyledPageContainer, SectionContainer } from '../styles/common'
 import { StyledSubHeader } from '../pageStyles/help.styles'
 import { TextContainer } from '../pageStyles/home.styles'
 import { theme } from '../styles/theme'
+import { GetServerSideProps } from 'next'
+import { getServerSideSessionOrRedirect } from '../server/getServerSideSessionOrRedirect'
 
 function createData (
   email: string,
@@ -209,4 +211,6 @@ const Help: NextPage = () => {
     </Layout>
   )
 }
+
+export const getServerSideProps: GetServerSideProps = getServerSideSessionOrRedirect
 export default Help


### PR DESCRIPTION
Check serverside props to mandate users be logged in to view email help sender.

Fixes #[67](https://github.com/HackBeanpot/internal-tools/issues/67).

This behavior is in alignment with all other pages of the app. No page should be accessible without authentication, and the change had been applied to all but the Help page.

Testing:
Logged out and verified that going to the email sender URL redirects to http://localhost:3000/auth/signin.