### PR TITLE
Error Handling (datetime, require subject style selection & remove upload cancellation bug)

### DIFF
--- a/components/subjectSection/subjectSection.tsx
+++ b/components/subjectSection/subjectSection.tsx
@@ -25,6 +25,7 @@ export default function SubjectSection ({
           aria-labelledby="choose-email-subject"
           name="email-subject"
           onChange={handleEmailStandard}
+          defaultValue="customized"
         >
           <FormControlLabel
             value="customized"

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -261,6 +261,38 @@ const EmailSender: NextPage = () => {
   const sendEmails = () => {
     // format: 'FName LName <email@hackbeanpot.com>'
     const from = '' + session?.user?.name + ' <' + session?.user?.email + '>'
+    if (checkedDeliveryBox) {
+      if (dateTime === undefined || dateTime === null) {
+        setErrorMessages([
+          {
+            id: nanoid(),
+            message: 'No delivery time is provided'
+          }
+        ])
+        return
+      }
+      if (dateTime !== undefined && dateTime !== null) {
+        const curDate = new Date()
+        const latestAllowedDate = new Date(new Date().setHours(curDate.getHours() + 72))
+        if (dateTime! < curDate) {
+          setErrorMessages([
+            {
+              id: nanoid(),
+              message: 'Cannot select an email send time that has already passed'
+            }
+          ])
+          return
+        } else if (dateTime! > latestAllowedDate) {
+          setErrorMessages([
+            {
+              id: nanoid(),
+              message: 'Cannot schedule email over 72 hours in advance'
+            }
+          ])
+          return
+        }
+      }
+    }
     const dataToSend = {
       emailData: finalMessages,
       from,

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -268,32 +268,26 @@ const EmailSender: NextPage = () => {
     const from = '' + session?.user?.name + ' <' + session?.user?.email + '>'
     if (checkedDeliveryBox) {
       if (dateTime === undefined || dateTime === null) {
-        setErrorMessages([
-          {
-            id: nanoid(),
-            message: 'No delivery time is provided'
-          }
-        ])
+        setResultMessage({
+          isError: true,
+          message: 'No delivery time is provided'
+        })
         return
       }
       if (dateTime !== undefined && dateTime !== null) {
         const curDate = new Date()
         const latestAllowedDate = new Date(new Date().setHours(curDate.getHours() + 72))
         if (dateTime! < curDate) {
-          setErrorMessages([
-            {
-              id: nanoid(),
-              message: 'Cannot select an email send time that has already passed'
-            }
-          ])
+          setResultMessage({
+            isError: true,
+            message: 'Cannot select an email send time that has already passed'
+          })
           return
         } else if (dateTime! > latestAllowedDate) {
-          setErrorMessages([
-            {
-              id: nanoid(),
-              message: 'Cannot schedule email over 72 hours in advance'
-            }
-          ])
+          setResultMessage({
+            isError: true,
+            message: 'Cannot schedule email over 72 hours in advance'
+          })
           return
         }
       }

--- a/pages/emailSender.tsx
+++ b/pages/emailSender.tsx
@@ -93,7 +93,12 @@ const EmailSender: NextPage = () => {
     reader = new window.FileReader()
   }
   const handleUploadCsv = (e: any) => {
-    const filename = e.target.files[0].name
+    let filename = ''
+    while (filename === '') {
+      if (e.target.files.length > 0) {
+        filename = e.target.files[0].name
+      }
+    }
     if (filename.substring(filename.length - 3) !== 'csv') {
       setErrorMessages([
         {


### PR DESCRIPTION
Implement error handling for edge cases in the email sender.

Fixes #[70](https://github.com/HackBeanpot/internal-tools/).

Changelist:
- Update code to not error upon cancellation of CSV uploads & proceeding only when uploads are complete
- Make subject customization the default option for subject selection (field 1 on sender)
- Print custom datetime selection errors for: no time given, time before current time, time more than 72 hours out

Tested: manual