### PR TITLE
clarify email input

### DIFF
--- a/components/emailSignature/emailSignatureForm.styles.tsx
+++ b/components/emailSignature/emailSignatureForm.styles.tsx
@@ -2,7 +2,7 @@ import { TextValidator } from 'react-material-ui-form-validator'
 import { styled } from '@mui/material/styles'
 
 const StyledTextValidator = styled(TextValidator)({
-  width: 280
+  width: 290
 })
 
 export {

--- a/components/emailSignature/emailSignatureForm.tsx
+++ b/components/emailSignature/emailSignatureForm.tsx
@@ -75,7 +75,7 @@ export default function EmailSignatureForm (
         {createValidatedInputField('fullName', formData.fullName, 'Full name')}
         {createValidatedInputField('title', formData.title, 'Title')}
         {createValidatedInputField('phone', formData.phone, 'Phone')}
-        {createValidatedInputField('email', formData.email, 'Email (@hackbeanpot.com)')}
+        {createValidatedInputField('email', formData.email, 'Email (exclude @hackbeanpot.com)')}
         {!embedded && (
           <StyledButton
             size="large"


### PR DESCRIPTION
Clarify the email field of the signature maker to be clear to exclude the @hackbeanpot.com 

Closes #105 

Changelist:
* changes description of the textbox (and fix styling accordingly)


Tested:
- Ran locally and checked responsiveness with different screensizes
  
Screenshots & Screencasts:
<img width="439" alt="Screenshot 2023-04-18 at 9 43 32 PM" src="https://user-images.githubusercontent.com/60558726/232944878-0c36f76a-74a9-4f82-94f9-07a3540c2379.png">
